### PR TITLE
Add meeting schedule link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,4 @@ please let us know on the [scheduling issue] so we can best accommodate everyone
 [open issues]: /issues
 [scheduling issue]: /issues/2
 [chat-link]: https://rust-lang.zulipchat.com/#narrow/stream/257204-project-error-handling
+[meeting-schedule]: https://doodle.com/poll/fkmvqvpq6eu68igi


### PR DESCRIPTION
Missing link

Got the link from here: https://rust-lang.zulipchat.com/#narrow/stream/257204-project-error-handling/topic/project.20process/near/210383871

If it's wrong please ignore :)